### PR TITLE
Improve VAD defaults and reporting

### DIFF
--- a/vad_example.py
+++ b/vad_example.py
@@ -16,11 +16,11 @@ def main(input_wav: str, output_txt: str):
         
         # Process with VAD
         vad = VADProcessor(
-            threshold=0.3,
-            min_speech_ms=100,
-            min_silence_ms=200,
-            speech_pad_ms=30,
-            use_cuda=False
+            threshold=0.65,
+            min_speech_ms=200,
+            min_silence_ms=250,
+            speech_pad_ms=35,
+            use_cuda=False,
         )
         segments = vad.process(audio, sr)
         print(f"Detected {len(segments)} speech segments")


### PR DESCRIPTION
## Summary
- tune Silero VAD defaults (threshold, durations, padding) and cap segment length
- adjust VAD-based chunking to close bins on long gaps, gate sparse speech, and report VAD intervals
- collect per-file comparison lines in text reports and move `shutil` import

## Testing
- `python -m py_compile vad_module.py inference_gigaam.py chunking_module.py vad_example.py`


------
https://chatgpt.com/codex/tasks/task_e_68c72d848fa48326a28baf0293555df1