### PR TITLE
Handle minimal speech per VAD bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Increasing `--vad_pad_ms` adds the specified milliseconds of context before and
 after every VAD segment prior to bin packing. This extra margin helps prevent
 words from being truncated at chunk boundaries, improving boundary safety.
 
+Use `--vad_min_bin_speech` to require a minimum amount of speech in each VAD
+bin. If a gap or duration limit would close the bin early, segments are merged
+with subsequent ones until this threshold is reached.
+
 To run plain VAD and save detected segments:
 
 ```bash

--- a/tests/test_slice_with_silero_vad.py
+++ b/tests/test_slice_with_silero_vad.py
@@ -1,0 +1,35 @@
+import numpy as np
+import sys
+from pathlib import Path
+import types
+
+# Provide stub modules before importing the real code
+stub_torch = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
+sys.modules.setdefault("torch", stub_torch)
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import inference_gigaam
+
+
+class DummyVADProcessor:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def process(self, audio, sr):
+        return [(0.0, 1.0), (3.0, 4.0), (10.0, 11.0)]
+
+
+def test_min_bin_speech_accumulates(monkeypatch):
+    monkeypatch.setattr(inference_gigaam, "VADProcessor", DummyVADProcessor)
+    sr = 1000
+    audio = np.zeros(sr * 12, dtype=np.float32)
+    chunks, _ = inference_gigaam.slice_with_silero_vad(
+        sr,
+        audio,
+        target_speech_sec=2.0,
+        max_silence_within_sec=1.2,
+        min_bin_speech_sec=3.0,
+    )
+    assert len(chunks) == 1
+    assert chunks[0] == (0, 11000)


### PR DESCRIPTION
## Summary
- ensure VAD chunk bins hold segments until a minimum speech threshold is met
- document and expose `--vad_min_bin_speech` behaviour
- add regression test for bin accumulation when speech is sparse

## Testing
- `python -m py_compile *.py tests/test_slice_with_silero_vad.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c73c1651808326bb905162a4abacd3