### PR TITLE
Add adaptive thresholding to chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Utilities for chunked speech transcription and voice activity detection.
   detecting speech segments. Supports an optional ``model_dir`` parameter to
   load pre-downloaded weights and avoid using ``torch.hub``.
 - **ChunkingProcessor**: splits long audio into manageable chunks based on
-  energy and optional overlap.
+  energy and optional overlap. Supports adaptive silence thresholds based on
+  noise-floor statistics which can be disabled with ``adaptive=False`` or the
+  ``--no_adaptive`` CLI flag.
 - **inference_gigaam.py**: command-line tool for transcribing long recordings
   with [GigaAM](https://github.com/salute-developers/GigaAM) models.
 - **rupunct_apply.py**: optional script that restores Russian punctuation on


### PR DESCRIPTION
## Summary
- add optional adaptive noise-floor threshold to `ChunkingProcessor`
- expose `--no_adaptive` flag in `inference_gigaam.py`
- document new parameter in README

## Testing
- `python -m py_compile *.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c73dc5d6f483269f1a058a319d7066