### PR TITLE
Add optional merging of close VAD segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Use `--vad_min_bin_speech` to require a minimum amount of speech in each VAD
 bin. If a gap or duration limit would close the bin early, segments are merged
 with subsequent ones until this threshold is reached.
 
+Pass `--vad_merge_segs` to merge adjacent VAD segments separated by short
+pauses. Gaps shorter than `--vad_min_gap_sec` are joined before bin packing,
+reducing excessive fragmentation of speech.
+
 To run plain VAD and save detected segments:
 
 ```bash

--- a/tests/test_slice_with_silero_vad.py
+++ b/tests/test_slice_with_silero_vad.py
@@ -33,3 +33,16 @@ def test_min_bin_speech_accumulates(monkeypatch):
     )
     assert len(chunks) == 1
     assert chunks[0] == (0, 11000)
+
+
+def test_merge_close_segments(monkeypatch):
+    monkeypatch.setattr(inference_gigaam, "VADProcessor", DummyVADProcessor)
+    sr = 1000
+    audio = np.zeros(sr * 12, dtype=np.float32)
+    _, segs = inference_gigaam.slice_with_silero_vad(
+        sr,
+        audio,
+        merge_close_segs=True,
+        min_gap_sec=2.5,
+    )
+    assert segs == [(0.0, 4.0), (10.0, 11.0)]


### PR DESCRIPTION
## Summary
- allow `slice_with_silero_vad` to merge adjacent segments separated by short gaps
- expose merging via new `--vad_merge_segs` CLI flag and document in README
- test merging of close segments

## Testing
- `python -m py_compile *.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c73f275ef08326bbb2459e557c2c9d