### PR TITLE
Log errors when skipping audio preconversion

### DIFF
--- a/inference_gigaam.py
+++ b/inference_gigaam.py
@@ -277,7 +277,8 @@ def _preconvert_if_needed(path: Path, repo_root: Path, force: bool = False) -> P
     try:
         subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return out_path
-    except Exception:
+    except Exception as e:
+        print(f"[preconvert] Conversion skipped for {path}: {e}")
         return path
 
 


### PR DESCRIPTION
## Summary
- print a message when audio preconversion is skipped due to conversion errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7411d9cc08326a39b6015ec979b90