### PR TITLE
Normalize and tokenize dedup comparison

### DIFF
--- a/tests/test_dedup_suffix_prefix.py
+++ b/tests/test_dedup_suffix_prefix.py
@@ -1,0 +1,29 @@
+import sys
+import types
+from pathlib import Path
+
+# Provide stub modules before importing the real code
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+sys.modules.setdefault("torch", types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False)))
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from inference_gigaam import _dedup_suffix_prefix
+
+
+def test_dedup_handles_punctuation_and_case():
+    tail = "Hello world,"
+    new = "world! How are you?"
+    assert _dedup_suffix_prefix(tail, new, min_overlap=1) == "How are you?"
+
+
+def test_dedup_token_boundary():
+    tail = "abc def"
+    new = "defg hi"
+    assert _dedup_suffix_prefix(tail, new, min_overlap=1) == "defg hi"
+
+
+def test_dedup_nfkc_normalization():
+    tail = "Café"
+    new = "CAFÉ is open"
+    assert _dedup_suffix_prefix(tail, new, min_overlap=1) == "is open"

--- a/tests/test_slice_with_silero_vad.py
+++ b/tests/test_slice_with_silero_vad.py
@@ -6,6 +6,7 @@ import types
 # Provide stub modules before importing the real code
 stub_torch = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
 sys.modules.setdefault("torch", stub_torch)
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 


### PR DESCRIPTION
## Summary
- Normalize dedup strings with NFKC and strip punctuation
- Compare suffix and prefix on word tokens instead of characters
- Cover word dedup logic with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c741553c8883268096ab2642dd764b