### PR TITLE
Handle stale GPU lock files

### DIFF
--- a/inference_gigaam.py
+++ b/inference_gigaam.py
@@ -190,8 +190,26 @@ def acquire_gpu_lock(lock_path: Path, timeout_s: int = 120) -> tuple[bool, int]:
             print(f"[LOCK] Acquired GPU lock at {lock_path}")
             return True, pid
         except FileExistsError:
+            try:
+                existing_pid = int(lock_path.read_text(encoding="utf-8").strip())
+                try:
+                    os.kill(existing_pid, 0)
+                except OSError:
+                    lock_path.unlink(missing_ok=True)
+                    continue
+            except Exception:
+                pass
             time.sleep(1)
         except Exception:
+            try:
+                existing_pid = int(lock_path.read_text(encoding="utf-8").strip())
+                try:
+                    os.kill(existing_pid, 0)
+                except OSError:
+                    lock_path.unlink(missing_ok=True)
+                    continue
+            except Exception:
+                pass
             time.sleep(1)
     return False, pid
 

--- a/tests/test_gpu_lock.py
+++ b/tests/test_gpu_lock.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from inference_gigaam import acquire_gpu_lock, release_gpu_lock
+
+
+def test_acquire_gpu_lock_removes_stale(tmp_path):
+    lock_path = tmp_path / "gpu.lock"
+    lock_path.write_text("999999", encoding="utf-8")
+    start = time.time()
+    acquired, pid = acquire_gpu_lock(lock_path, timeout_s=3)
+    elapsed = time.time() - start
+    assert acquired
+    assert pid == os.getpid()
+    assert elapsed < 1
+    assert lock_path.read_text(encoding="utf-8").strip() == str(pid)
+    release_gpu_lock(lock_path, pid)
+    assert not lock_path.exists()


### PR DESCRIPTION
## Summary
- Ensure GPU lock acquisition checks PID in existing lock file and removes stale locks immediately
- Add regression test verifying stale lock files are cleaned up before waiting

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c749f1db3483268ab91d136067d6e6